### PR TITLE
Add Valgrind to sql-receptionist

### DIFF
--- a/apps/sql-receptionist/Dockerfile
+++ b/apps/sql-receptionist/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.14.0-slim-bookworm AS builder
+FROM gcc:15-trixie AS builder
 WORKDIR /apps/sql-receptionist
 
 ENV LD_LIBRARY_PATH=/usr/local/lib
@@ -7,8 +7,6 @@ COPY ./apps/sql-receptionist .
 COPY ./config.yml /
 
 RUN apt-get update && apt-get install -y \
-    cmake \
-    build-essential \
     libpq-dev \
     libyaml-dev \
     wget \

--- a/apps/sql-receptionist/Dockerfile.dev
+++ b/apps/sql-receptionist/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM python:3.14.0-slim-bookworm AS builder
+FROM gcc:15-trixie AS builder
 WORKDIR /apps/sql-receptionist
 
 ENV LD_LIBRARY_PATH=/usr/local/lib
@@ -7,8 +7,6 @@ COPY ./apps/sql-receptionist .
 COPY ./config.yml /
 
 RUN apt-get update && apt-get install -y \
-    cmake \
-    build-essential \
     libpq-dev \
     libyaml-dev \
     wget \

--- a/apps/sql-receptionist/Dockerfile.dev
+++ b/apps/sql-receptionist/Dockerfile.dev
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y \
     libyaml-dev \
     wget \
     bzip2 \
+    valgrind \
     gnupg \
     # @TODO verification with gnupg
     # QoL

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -61,7 +61,7 @@ services:
         condition: service_healthy
     # compile and run the application.
     # Do not close the container on error.
-    command: bash -c "make clean && make && exec ./app || (echo 'The SQL Receptionist is now sleeping...' && sleep 3600)"
+    command: bash -c "make clean && make && exec ./app ; (echo 'The SQL Receptionist is now sleeping...' && sleep 3600)"
 
   wywywebsite_create_tables:
     container_name: wywywebsite_create_tables

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -61,7 +61,7 @@ services:
         condition: service_healthy
     # compile and run the application.
     # Do not close the container on error.
-    command: bash -c "trap 'exit 0' TERM; make clean && make && ./app || echo 'The SQL Receptionist is now sleeping...'; while true; do sleep 3600 & wait $!; done"
+    command: bash -c "make clean && make && exec ./app || (echo 'The SQL Receptionist is now sleeping...' && sleep 3600)"
 
   wywywebsite_create_tables:
     container_name: wywywebsite_create_tables

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -59,7 +59,9 @@ services:
     depends_on:
       wywywebsite_database:
         condition: service_healthy
-    command: bash -c "make clean && make && ./app"
+    # compile and run the application.
+    # Do not close the container on error.
+    command: bash -c "trap 'exit 0' TERM; make clean && make && ./app || echo 'The SQL Receptionist is now sleeping...'; while true; do sleep 3600 & wait $!; done"
 
   wywywebsite_create_tables:
     container_name: wywywebsite_create_tables

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -6,6 +6,7 @@ if [ -z "$1" ]; then
   exit 1
 fi
 
+rebuild=0
 endflags=""
 
 # Check for flags
@@ -13,6 +14,7 @@ while getopts "b" opt;
 do
     case "${opt}" in
     b)
+        rebuild=1
         endflags="${endflags} --build"
         ;;
     *)
@@ -27,12 +29,24 @@ shift $((OPTIND-1))
 
 case "$1" in
     prod)
+        if [ "$rebuild" -eq 1 ];
+        then
+            sudo chmod +rw "../apps/postgres/pgdata"
+            sudo chmod +rw "../apps/postgres/pgdata/**/*"
+        fi
+
         case "$2" in 
             astro) docker compose -f prod/docker-compose.astro.yml up${endflags}
         esac
         docker compose -f docker-compose.prod.yml up${endflags}
         ;;
     dev)
+        if [ "$rebuild" -eq 1 ];
+        then
+            sudo chmod +rw "../apps/postgres/pgdata"
+            sudo chmod +rw "../apps/postgres/pgdata/**/*"
+        fi
+        
         docker compose -f docker-compose.dev.yml up --watch${endflags}
         ;;
     *)

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,20 +1,39 @@
 #!/bin/bash
 # Check if an argument is provided
 if [ -z "$1" ]; then
-  echo "Error: No argument provided."
-  echo "Usage: $0 <prod | dev>"
+  echo "Error: No argument provided." >&2
+  echo "Usage: $0 <prod | dev>" >&2
   exit 1
 fi
+
+endflags=""
+
+# Check for flags
+while getopts "b" opt;
+do
+    case "${opt}" in
+    b)
+        endflags="${endflags} --build"
+        ;;
+    *)
+        echo "Invalid flag \"-${opt}\". Expected -b for build." &>2
+        exit 1
+        ;;
+    esac
+done
+
+# shift args so that position arguments make sense
+shift $((OPTIND-1))
 
 case "$1" in
     prod)
         case "$2" in 
-            astro) docker compose -f prod/docker-compose.astro.yml up
+            astro) docker compose -f prod/docker-compose.astro.yml up${endflags}
         esac
-        docker compose -f docker-compose.prod.yml up
+        docker compose -f docker-compose.prod.yml up${endflags}
         ;;
     dev)
-        docker compose -f docker-compose.dev.yml up --watch
+        docker compose -f docker-compose.dev.yml up --watch${endflags}
         ;;
     *)
         echo "Error: Invalid argument '$1'. Expected 'prod' or 'dev'"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -43,10 +43,10 @@ case "$1" in
     dev)
         if [ "$rebuild" -eq 1 ];
         then
-            sudo chmod +rw "../apps/postgres/pgdata"
-            sudo chmod +rw "../apps/postgres/pgdata/**/*"
+            sudo chmod +rwx "../apps/postgres/pgdata"
+            sudo chmod +rwx "../apps/postgres/pgdata/**/*"
         fi
-        
+
         docker compose -f docker-compose.dev.yml up --watch${endflags}
         ;;
     *)


### PR DESCRIPTION
sql-receptionist no longer exits the container upon application failure (e.g. SIGSEV). This will enable GDB to post-mortem inspect.

Added Valgrind to the sql-receptionist image.

Switched sql-receptionist to a gcc image (as it should've been a long time ago).

Added an optional -b flag to run.sh.