### PR TITLE
Sqlr hotfix

### DIFF
--- a/apps/sql-receptionist/include/server/responses.h
+++ b/apps/sql-receptionist/include/server/responses.h
@@ -1,5 +1,4 @@
 #include <stdlib.h>
-extern void init(struct config *cfg);
 extern void build_response(int status_code, char **response,
                            size_t *response_len, char *body);
 extern void build_response_printf(int status_code, char **response,

--- a/apps/sql-receptionist/src/app.c
+++ b/apps/sql-receptionist/src/app.c
@@ -54,13 +54,13 @@ int done;
 void handle_sigterm(int signal_num) {
   printf("Received SIGTERM. Exiting now...\n");
   done = 1;
-  exit(1);
+  exit(0);
 }
 
 void handle_sigint(int signal_num) {
   printf("Received SIGINT. Exiting now...\n");
   done = 1;
-  exit(1);
+  exit(0);
 }
 
 char *admin_creds;

--- a/apps/sql-receptionist/src/app.c
+++ b/apps/sql-receptionist/src/app.c
@@ -233,7 +233,7 @@ void *handle_client(void *arg) {
   }
 
   // receive request data from client and store into buffer
-  ssize_t bytes_received = recv(client_fd, buffer, BUFFER_SIZE, 0);
+  ssize_t bytes_received = recv(client_fd, buffer, BUFFER_SIZE - 1, 0);
 
   // printf("%s\n", buffer);
 
@@ -241,6 +241,8 @@ void *handle_client(void *arg) {
     build_response(400, &response, &response_len, "No request data received.");
     goto end;
   }
+
+  buffer[bytes_received] = '\0';
 
   // @warning HTTP/1 not matching?
   // ^([A-Z]+) /([^ ]*) HTTP/[12]\\.[0-9]

--- a/apps/sql-receptionist/src/app.c
+++ b/apps/sql-receptionist/src/app.c
@@ -1022,7 +1022,6 @@ int main(int argc, char const *argv[]) {
 
   // populate global variables
   load_config(&global_config);
-  init(global_config);
   if (global_config == NULL) {
     fprintf(stderr, "Failed to load configuration.\n");
     return EXIT_FAILURE;

--- a/apps/sql-receptionist/src/app.c
+++ b/apps/sql-receptionist/src/app.c
@@ -998,6 +998,10 @@ int main(int argc, char const *argv[]) {
     fprintf(stderr, "Could not find environment variable DATABASE_PASSWORD.");
     exit(EXIT_FAILURE);
   }
+  if (!getenv("MAIN_URL")) {
+    fprintf(stderr, "Could not find environment variable MAIN_URL");
+    exit(EXIT_FAILURE);
+  }
 
   // attempt to read admin password
   admin_creds = malloc(MAX_PASSWORD_LENGTH + 1);

--- a/apps/sql-receptionist/src/server/responses.c
+++ b/apps/sql-receptionist/src/server/responses.c
@@ -9,20 +9,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-static const struct config *global_config = NULL;
-
-/**
- * Loads in a config. This config will be used to provide the correct headers
- * for CORS.
- * @param cfg The config to load in.
- */
-void init(const struct config *cfg) {
-  global_config = cfg;
-
-  // @TODO check validity
-}
-
 /**
  * Returns the name associated with the given status code.
  * @return the name associated with the given status code.
@@ -56,10 +42,6 @@ const char *get_status_code_name(int status_code) {
  */
 void build_response(int status_code, char **response, size_t *response_len,
                     char *body) {
-  if (!global_config) {
-    perror("Cannot build response because the config is NULL.");
-    exit(EXIT_FAILURE);
-  }
   const char *status_code_name = get_status_code_name(status_code);
 
   if (getenv("SQL_RECEPTIONIST_LOG_RESPONSES") &&

--- a/apps/sql-receptionist/src/server/responses.c
+++ b/apps/sql-receptionist/src/server/responses.c
@@ -82,6 +82,10 @@ void build_response(int status_code, char **response, size_t *response_len,
                   strlen(status_code_name) + strlen(getenv("MAIN_URL")) +
                   strlen(connection) + strlen(body);
   *response = malloc(*response_len + 1);
+  if (!*response) {
+    perror("Malloc failure on *response.");
+    return;
+  }
   snprintf(*response, *response_len + 1,
            "HTTP/1.1 %d %s\r\n"
            "Content-Type: text/plain\r\n"


### PR DESCRIPTION
Hotfix a segmentation fault which occurred when/after handling a request with an empty body.

I believe the bug was from the buffer which was not necessarily null terminated. The bug might have happened because the request was not fully sent in and then the null terminator was cut off. Now sqlr should be able to handle non-null terminated inputs.