### PR TITLE
Pointers & polypointers

### DIFF
--- a/apps/astro-app/src/components/data/chart/dataset-control-panel.tsx
+++ b/apps/astro-app/src/components/data/chart/dataset-control-panel.tsx
@@ -1,4 +1,4 @@
-import type { EChartsDataset, TableInfo } from "@/types/data";
+import type { DatabaseInfo, EChartsDataset, TableInfo } from "@/types/data";
 import { DATABASE_URL } from "astro:env/client";
 import type { JSX } from "astro/jsx-runtime";
 import { useEffect, useState } from "react";
@@ -14,9 +14,13 @@ import {
   prettyParseTimestamp,
   prettifySnakeCase,
 } from "@utils/parse";
+import {
+  SchemaProvider,
+  useDatabaseName,
+} from "@utils/data/schema-context";
 
 type DatasetControlPanelProps = {
-  databaseName: string;
+  databaseInfo: DatabaseInfo;
   tableSchema: TableInfo;
 };
 
@@ -36,9 +40,22 @@ const prettyParseFunctions = {
 };
 
 export default function DatasetControlPanel({
-  databaseName,
+  databaseInfo,
   tableSchema,
 }: DatasetControlPanelProps): JSX.Element {
+  return (
+    <SchemaProvider databaseInfo={databaseInfo} tableInfo={tableSchema}>
+      <DatasetControlPanelBody tableSchema={tableSchema} />
+    </SchemaProvider>
+  );
+}
+
+function DatasetControlPanelBody({
+  tableSchema,
+}: {
+  tableSchema: TableInfo;
+}): JSX.Element {
+  const databaseName = useDatabaseName();
   const [dataset, setDataset] = useState<EChartsDataset>([]);
   const [columns, setColumns] = useState<Array<any>>([]);
 

--- a/apps/astro-app/src/components/data/dashboard.tsx
+++ b/apps/astro-app/src/components/data/dashboard.tsx
@@ -12,6 +12,7 @@ import React, { useEffect, useMemo, useState, type JSX } from "react";
 import { toast } from "sonner";
 import { MATH } from "@utils/math";
 import { GenericChart } from "./chart";
+import { SchemaProvider, useDatabaseInfo } from "@utils/data/schema-context";
 
 /**
  * Attempts to fetch a dataset. The URL to GET from is "[endpoint]/[target]?querystring"
@@ -104,6 +105,15 @@ export function Dashboard({
 }: {
   databaseInfo: DatabaseInfo;
 }): JSX.Element {
+  return (
+    <SchemaProvider databaseInfo={databaseInfo}>
+      <DashboardInner />
+    </SchemaProvider>
+  );
+}
+
+function DashboardInner(): JSX.Element {
+  const databaseInfo = useDatabaseInfo();
   const [loadingDataState, setLoadingDataState] = useState<boolean>(false);
   const [errorState, setErrorState] = useState<boolean>(false);
   const [refreshState, setRefreshState] = useState<number>(0);

--- a/apps/astro-app/src/components/data/data-entry-form.tsx
+++ b/apps/astro-app/src/components/data/data-entry-form.tsx
@@ -1,41 +1,39 @@
 "use client";
 
-import type { TableInfo } from "@/types/data";
+import type { DatabaseInfo, TableInfo } from "@/types/data";
 import type { JSX } from "astro/jsx-runtime";
 import { FormForm } from "@/components/data/data-entry/form";
 import { TimerForm } from "@/components/data/data-entry/timer";
+import { SchemaProvider, useTableInfo } from "@utils/data/schema-context";
 
 /**
  * Selects the correct form element to use. Expects there to be a valid Toast element inside the page.
- * @param databaseName The name of the database that this form gathers data for.
+ * @param databaseInfo The full database info.
  * @param tableInfo The full table schema.
- * @param dbURL The URL that the form will post to on submit.
+ * @param onSubmitted Called after a successful form submission.
  */
 export default function DataEntryForm({
-  databaseName,
+  databaseInfo,
   tableInfo,
-  submissionCallback = () => {},
+  onSubmitted,
 }: {
-  databaseName: string;
+  databaseInfo: DatabaseInfo;
   tableInfo: TableInfo;
-  submissionCallback?: () => void;
+  onSubmitted?: () => void;
 }): JSX.Element {
+  return (
+    <SchemaProvider databaseInfo={databaseInfo} tableInfo={tableInfo}>
+      <DataEntryFormBody onSubmitted={onSubmitted} />
+    </SchemaProvider>
+  );
+}
+
+function DataEntryFormBody({ ...props }) {
+  const tableInfo = useTableInfo()!;
   switch (tableInfo.entrytype) {
     case "form":
-      return (
-        <FormForm
-          databaseName={databaseName}
-          tableInfo={tableInfo}
-          submissionCallback={submissionCallback}
-        />
-      );
+      return <FormForm {...props} />;
     case "timer":
-      return (
-        <TimerForm
-          databaseName={databaseName}
-          tableInfo={tableInfo}
-          submissionCallback={submissionCallback}
-        />
-      );
+      return <TimerForm {...props} />;
   }
 }

--- a/apps/astro-app/src/components/data/data-entry.tsx
+++ b/apps/astro-app/src/components/data/data-entry.tsx
@@ -3,7 +3,7 @@ import {
   ConstantFormElement,
   FormElement,
 } from "@/components/data/input-elements";
-import type { DataColumn, DescriptorInfo, TableInfo } from "@/types/data";
+import type { DataColumn, DescriptorInfo } from "@/types/data";
 import {
   Card,
   CardContent,
@@ -20,6 +20,7 @@ import { SearchSelect } from "./input-element/search-select";
 import { useMemo, useState } from "react";
 import type { TAG_NAMES_DATASET } from "@utils/data/schema";
 import { toSnakeCase } from "@utils/parse";
+import { useTableInfo } from "@utils/data/schema-context";
 
 export function Columns({
   fieldsToEnter,
@@ -290,17 +291,15 @@ function DescriptorTab({
 
 /**
  * The desciptor related form component. Dialogs are used to enter in the descriptors because it is assumed that each desciptor does not have a lot of associated information.
- * @param tableInfo The schema for the respective table.
  * @param form The controller for the overarching form.
  * @returns
  */
 export function Descriptors({
-  tableInfo,
   form,
 }: {
-  tableInfo: TableInfo;
   form: any;
 }): JSX.Element {
+  const tableInfo = useTableInfo()!;
   if (tableInfo.descriptors.length == 0) return null;
 
   return (

--- a/apps/astro-app/src/components/data/data-entry/form.tsx
+++ b/apps/astro-app/src/components/data/data-entry/form.tsx
@@ -8,7 +8,7 @@ import { CACHE_URL } from "astro:env/client";
 import type z from "zod";
 import { submitEntry, useDataset } from "@utils/data/http";
 import { toast } from "sonner";
-import type { FieldErrors } from "react-hook-form";
+import { FormProvider, type FieldErrors } from "react-hook-form";
 import { toSnakeCase } from "@utils/parse";
 import { useEffect, useState } from "react";
 import { useAutoPopulate } from "@utils/data/form/useAutoPopulate";
@@ -85,7 +85,8 @@ export function FormForm({
   }
 
   return (
-    <form onSubmit={(e) => e.preventDefault()} className="flex flex-col gap-4">
+    <FormProvider {...controller}>
+      <form onSubmit={(e) => e.preventDefault()} className="flex flex-col gap-4">
       <Columns fieldsToEnter={tableInfo.schema} form={controller} />
       {tableInfo.tagging ? (
         tagsLoading ? (
@@ -124,7 +125,8 @@ export function FormForm({
         onClick={handleSubmitClick}
       >
         {isSubmitting ? <Spinner /> : "Submit"}
-      </Button>
-    </form>
+        </Button>
+      </form>
+    </FormProvider>
   );
 }

--- a/apps/astro-app/src/components/data/data-entry/form.tsx
+++ b/apps/astro-app/src/components/data/data-entry/form.tsx
@@ -2,7 +2,6 @@
 
 import { Button } from "@/components/ui/button";
 
-import type { TableInfo } from "@/types/data";
 import { createFormController } from "@utils/data/form/full-entry-handlers";
 import { Columns, Tags, Descriptors } from "@/components/data/data-entry";
 import { CACHE_URL } from "astro:env/client";
@@ -16,21 +15,21 @@ import { useAutoPopulate } from "@utils/data/form/useAutoPopulate";
 import { Spinner } from "@/components/ui/spinner";
 import { RefreshCcw } from "lucide-react";
 import { type TAG_NAMES_DATASET } from "@utils/data/schema";
+import {
+  useDatabaseName,
+  useTableInfo,
+} from "@utils/data/schema-context";
 
 /**
  * Basic form component.
- * @param databaseName The name of the database that this form gathers data for.
- * @param tableInfo The full table schema.
  */
 export function FormForm({
-  databaseName,
-  tableInfo,
-  submissionCallback = () => {},
+  onSubmitted,
 }: {
-  databaseName: string;
-  tableInfo: TableInfo;
-  submissionCallback?: () => void;
+  onSubmitted?: () => void;
 }) {
+  const databaseName = useDatabaseName();
+  const tableInfo = useTableInfo()!;
   // TODO: extract a reusable form stage hook (idle -> populating -> ready -> submitting -> submitted)
   const { controller, schema } = createFormController(tableInfo);
   const { populate, isPopulating } = useAutoPopulate(tableInfo, controller);
@@ -76,7 +75,7 @@ export function FormForm({
         },
       )();
 
-      if (submitted) submissionCallback();
+      if (submitted) onSubmitted?.();
     } catch (reason) {
       toast(`Form submission failed: ${reason}`);
       console.error(`Form submission failed: ${reason}`);
@@ -117,7 +116,7 @@ export function FormForm({
         ) : null
       ) : null}
       {tableInfo.descriptors ? (
-        <Descriptors tableInfo={tableInfo} form={controller} />
+        <Descriptors form={controller} />
       ) : null}
       <Button
         type="button"

--- a/apps/astro-app/src/components/data/data-entry/form.tsx
+++ b/apps/astro-app/src/components/data/data-entry/form.tsx
@@ -4,19 +4,23 @@ import { Button } from "@/components/ui/button";
 
 import type { TableInfo } from "@/types/data";
 import { createFormController } from "@utils/data/form/full-entry-handlers";
-import { Columns } from "@/components/data/data-entry";
+import { Columns, Tags, Descriptors } from "@/components/data/data-entry";
 import { CACHE_URL } from "astro:env/client";
 import type z from "zod";
-import { submitEntry } from "@utils/data/http";
+import { submitEntry, useDataset } from "@utils/data/http";
 import { toast } from "sonner";
 import type { FieldErrors } from "react-hook-form";
 import { toSnakeCase } from "@utils/parse";
+import { useEffect, useState } from "react";
+import { useAutoPopulate } from "@utils/data/form/useAutoPopulate";
+import { Spinner } from "@/components/ui/spinner";
+import { RefreshCcw } from "lucide-react";
+import { type TAG_NAMES_DATASET } from "@utils/data/schema";
 
 /**
  * Basic form component.
  * @param databaseName The name of the database that this form gathers data for.
  * @param tableInfo The full table schema.
- * @param dbURL The URL that the form will post to on submit.
  */
 export function FormForm({
   databaseName,
@@ -27,41 +31,101 @@ export function FormForm({
   tableInfo: TableInfo;
   submissionCallback?: () => void;
 }) {
+  // TODO: extract a reusable form stage hook (idle -> populating -> ready -> submitting -> submitted)
   const { controller, schema } = createFormController(tableInfo);
+  const { populate, isPopulating } = useAutoPopulate(tableInfo, controller);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [tagsRefreshState, setTagsRefreshState] = useState<number>(0);
 
-  function onSubmit(
-    values: z.infer<typeof schema>,
-    event?: React.BaseSyntheticEvent,
-  ): void {
-    submitEntry(
-      `${CACHE_URL}/main/${databaseName}/${toSnakeCase(tableInfo.tableName)}`,
-      values,
-      "cache",
-    )
-      .then(() => {
-        toast("Form submitted!");
-        submissionCallback();
-      })
-      .catch((reason) => {
-        toast(`Form submission failed: ${reason}`);
-        console.log(`Form submission failed: ${reason}`);
-      });
-  }
+  const [tagNamesDataset, tagsLoading, tagsError] = useDataset({
+    valid: tableInfo.tagging === true,
+    table_type: "tag_names",
+    schema: undefined,
+    source: "cache",
+    endpointOptions: {
+      databaseName,
+      tableName: tableInfo.tableName,
+    },
+    refreshState: tagsRefreshState,
+  });
 
-  function onSubmitInvalid(errors: FieldErrors<z.infer<typeof schema>>) {
-    console.error("Invalid form submission.", errors);
-    toast("Invalid form submission.");
+  useEffect(() => {
+    populate("start");
+  }, []);
+
+  const endpoint = `${CACHE_URL}/main/${toSnakeCase(databaseName)}/${toSnakeCase(tableInfo.tableName)}`;
+
+  // Populates submit-time columns then validates and sends the form entry
+  async function handleSubmitClick() {
+    if (isSubmitting) return;
+    setIsSubmitting(true);
+
+    try {
+      await populate("submit");
+
+      let submitted = false;
+      await controller.handleSubmit(
+        async (values: z.infer<typeof schema>) => {
+          await submitEntry(endpoint, values, "cache");
+          toast("Form submitted!");
+          submitted = true;
+        },
+        (errors: FieldErrors<z.infer<typeof schema>>) => {
+          console.error("Invalid form submission.", errors);
+          toast("Invalid form submission.");
+        },
+      )();
+
+      if (submitted) submissionCallback();
+    } catch (reason) {
+      toast(`Form submission failed: ${reason}`);
+      console.error(`Form submission failed: ${reason}`);
+    } finally {
+      setIsSubmitting(false);
+    }
   }
 
   return (
-    <form
-      onSubmit={controller.handleSubmit(onSubmit, onSubmitInvalid)}
-      className="flex flex-col gap-4"
-    >
+    <form onSubmit={(e) => e.preventDefault()} className="flex flex-col gap-4">
       <Columns fieldsToEnter={tableInfo.schema} form={controller} />
-      {/* @TODO add tags */}
-      {/* @TODO add descriptors */}
-      <Button type="submit">Submit</Button>
+      {tableInfo.tagging ? (
+        tagsLoading ? (
+          <div className="flex flex-col items-center">
+            <p>Loading tags...</p>
+            <Spinner />
+          </div>
+        ) : tagsError ? (
+          <div className="flex flex-col items-center">
+            <p>Error while loading tags.</p>
+            <Button
+              onClick={() => {
+                setTagsRefreshState(tagsRefreshState + 1);
+              }}
+            >
+              <RefreshCcw />
+            </Button>
+          </div>
+        ) : tagNamesDataset ? (
+          <>
+            {/* @TODO tag suggestions — pick the most likely tag instead of the first one */}
+            <Tags
+              /* type assertion: useDataset validates against TAG_NAMES_DATASET_SCHEMA internally, so the cast is safe */
+              tagsDataset={tagNamesDataset as TAG_NAMES_DATASET}
+              form={controller}
+            />
+          </>
+        ) : null
+      ) : null}
+      {tableInfo.descriptors ? (
+        <Descriptors tableInfo={tableInfo} form={controller} />
+      ) : null}
+      <Button
+        type="button"
+        disabled={isSubmitting || isPopulating}
+        onClick={handleSubmitClick}
+      >
+        {isSubmitting ? <Spinner /> : "Submit"}
+      </Button>
     </form>
   );
 }

--- a/apps/astro-app/src/components/data/data-entry/timer.tsx
+++ b/apps/astro-app/src/components/data/data-entry/timer.tsx
@@ -432,7 +432,7 @@ export function TimerForm({
           )}
         </Button>
         {/* Submit button */}
-        <Button type="submit">Submit</Button>
+        <Button type="submit" disabled={isSubmitting}>Submit</Button>
         {/* Columns */}
         <Columns fieldsToEnter={tableInfo.schema} form={controller} />
         {/* Quick actions */}

--- a/apps/astro-app/src/components/data/data-entry/timer.tsx
+++ b/apps/astro-app/src/components/data/data-entry/timer.tsx
@@ -12,7 +12,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { GeodeticCoordinate } from "@utils/datatypes/geodetic";
 import { createFormController } from "@/utils/data/form/full-entry-handlers";
 import { submitEntry, useDataset } from "@/utils/data/http";
-import type { FieldErrors } from "react-hook-form";
+import { FormProvider, type FieldErrors } from "react-hook-form";
 import {
   TAG_NAMES_DATASET_SCHEMA,
   type TAG_NAMES_DATASET,
@@ -352,10 +352,11 @@ export function TimerForm({
       );
 
     return (
-      <form
-        onSubmit={controller.handleSubmit(onSubmit, onSubmitInvalid)}
-        className="flex flex-col gap-4"
-      >
+      <FormProvider {...controller}>
+        <form
+          onSubmit={controller.handleSubmit(onSubmit, onSubmitInvalid)}
+          className="flex flex-col gap-4"
+        >
         <Button type="button" disabled={isCaching} onClick={cancelSplit}>
           {isCaching ? (
             <div className="flex flex-row justify-center items-center gap-2">
@@ -384,8 +385,9 @@ export function TimerForm({
         <Button type="submit" disabled={isSubmitting} value="split">
           Submit & Restart
           {isSubmitting ? <Spinner /> : null}
-        </Button>
-      </form>
+          </Button>
+        </form>
+      </FormProvider>
     );
   }
 

--- a/apps/astro-app/src/components/data/data-entry/timer.tsx
+++ b/apps/astro-app/src/components/data/data-entry/timer.tsx
@@ -1,53 +1,25 @@
 import type { TableInfo } from "@/types/data";
 import { Button } from "@/components/ui/button";
-import { useEffect, useState, type Dispatch, type SetStateAction } from "react";
+import { useEffect, useState } from "react";
 import { Columns, Descriptors, Tags } from "@/components/data/data-entry";
 import type z from "zod";
 import { toast } from "sonner";
 import { getCSRFToken } from "@utils/auth";
 import { parseDatabaseValue } from "@utils/data/deserialization";
-import { handleRecordOn } from "@utils/data/form/updates";
 import type { JSONValue } from "@/types/http";
 import { CACHE_URL } from "astro:env/client";
 import { RefreshCcw, Upload } from "lucide-react";
 import { Spinner } from "@/components/ui/spinner";
 import { GeodeticCoordinate } from "@utils/datatypes/geodetic";
 import { createFormController } from "@/utils/data/form/full-entry-handlers";
-import { safeFetchDataset, submitEntry } from "@/utils/data/http";
+import { submitEntry, useDataset } from "@/utils/data/http";
 import type { FieldErrors } from "react-hook-form";
 import {
   TAG_NAMES_DATASET_SCHEMA,
   type TAG_NAMES_DATASET,
 } from "@utils/data/schema";
 import { toSnakeCase } from "@utils/parse";
-
-/**
- * Helper to a load tag names dataset. Assumes that only one concurrent fetch can occur.
- * @param endpoint The endpoint to GET.
- * @param setTagNames The setter for the tagNames dataset.
- * @param setTagsLoading The setter for the loading state.
- */
-function loadTagNames(
-  endpoint: string,
-  setTagNames: Dispatch<SetStateAction<TAG_NAMES_DATASET | undefined>>,
-  setTagsLoading: Dispatch<SetStateAction<boolean>>,
-) {
-  // only allow one concurrent fetch
-  setTagsLoading(true);
-
-  // safe fetch dataset
-  safeFetchDataset(endpoint, TAG_NAMES_DATASET_SCHEMA)
-    .then((tagNames) => {
-      setTagNames(tagNames);
-    })
-    .catch((reason) => {
-      toast(`Failed to load tags: ${reason}`);
-      setTagNames(undefined);
-    })
-    .finally(() => {
-      setTagsLoading(false);
-    });
-}
+import { useAutoPopulate } from "@utils/data/form/useAutoPopulate";
 
 /**
  * Timer based form component. Expects "Start Time" & "End Time" columns to be present.
@@ -65,18 +37,34 @@ export function TimerForm({
 }) {
   const [isSplit, setIsSplit] = useState<boolean>(false);
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
-  const [tagNames, setTagNames] = useState<TAG_NAMES_DATASET>();
-  const [tagsLoading, setTagsLoading] = useState<boolean>(false);
   const [tagsRefreshState, setTagsRefreshState] = useState<number>(0);
   const [isCaching, setIsCaching] = useState<boolean>(false);
   const [cacheError, setCacheError] = useState<boolean>(false);
-  const [data, setData] = useState<Record<string, any>>({});
 
-  const isStart: boolean = Object.keys(data).length > 0;
   const { controller, schema } = createFormController(tableInfo);
+  const { populate } = useAutoPopulate(tableInfo, controller);
 
+  const startTime = controller.watch("data.start_time");
+  const isStart: boolean = startTime != null;
+
+  const [tagNamesDataset, tagsLoading, tagsError] = useDataset({
+    valid: isSplit && !cacheError,
+    table_type: "tag_names",
+    schema: undefined,
+    source: "cache",
+    endpointOptions: {
+      databaseName,
+      tableName: tableInfo.tableName,
+    },
+    refreshState: tagsRefreshState,
+  });
+  // type assertion: fallback to undefined preserves the expected type while useDataset gates rendering behind loading/error checks
+  const tagNames =
+    tagNamesDataset ??
+    (undefined as unknown as z.infer<typeof TAG_NAMES_DATASET_SCHEMA>);
+
+  // GETs the cached start/end times from the cache server and injects them into the controller
   function fetchCache() {
-    // only allow one concurrent fetch
     if (isCaching) return;
     setIsCaching(true);
 
@@ -103,7 +91,6 @@ export function TimerForm({
             for (const columnSchema of tableInfo.schema) {
               const columnName = toSnakeCase(columnSchema.name);
               if (columnName in body) {
-                // transform dates to UTC
                 switch (columnSchema.datatype) {
                   case "geodetic point":
                     if (typeof body[columnName] != "string") {
@@ -152,7 +139,11 @@ export function TimerForm({
               }
             }
 
-            setData(output);
+            for (const [key, value] of Object.entries(output)) {
+              controller.setValue(`data.${key}`, value, {
+                shouldValidate: true,
+              });
+            }
             setIsCaching(false);
             setCacheError(false);
           })
@@ -176,164 +167,110 @@ export function TimerForm({
   // initally try to GET the start time
   useEffect(fetchCache, []);
 
+  // @TODO tag suggestions — pick the most likely tag instead of the first one
+  // automatically set primary_tag when tag names load
   useEffect(() => {
-    // always keep controller data up to date
-    for (const key in data) {
-      controller.setValue(`data.${key}`, data[key], {
-        shouldValidate: true,
-        shouldTouch: false,
-      });
+    if (tagNamesDataset) {
+      controller.setValue("data.primary_tag", tagNamesDataset["data"][0][0]);
     }
-
-    // automatically update the cache when the user changes either the start or the end time.
-    // only update when desired & valid
-    if (cacheError || !isCaching) return;
-    // update form values
-
-    cache();
-  }, [data]);
-
-  // fetch tags
-  useEffect(() => {
-    // require no cache error & split
-    if (!isSplit || cacheError) return;
-
-    // only allow one concurrent fetch
-    if (tagsLoading) return;
-    setTagsLoading(true);
-
-    // safe fetch dataset
-    safeFetchDataset(
-      `${CACHE_URL}/main/${toSnakeCase(databaseName)}/${toSnakeCase(tableInfo.tableName)}/tag_names`,
-      TAG_NAMES_DATASET_SCHEMA,
-    )
-      .then((tagNames) => {
-        setTagNames(tagNames);
-        controller.resetField("data.primary_tag", {
-          defaultValue: tagNames["data"][0][0],
-        });
-      })
-      .catch((reason) => {
-        toast(`Failed to load tags: ${reason}`);
-        setTagNames(undefined);
-      })
-      .finally(() => {
-        setTagsLoading(false);
-      });
-  }, [isSplit, cacheError, tagsRefreshState]);
+  }, [tagNamesDataset]);
 
   /**
    * Stores the startTime and endTime into the cache.
    */
-  function cache() {
-    // store values in cache
-    // @TODO don't hardcode start_time & end_time
-    getCSRFToken("cache")
-      .then((csrftoken: string) => {
-        fetch(`${CACHE_URL}/cache/${databaseName}/${tableInfo.tableName}`, {
+  async function cache(customData?: Record<string, any>) {
+    try {
+      const cacheData = customData ?? controller.getValues("data");
+      const csrftoken = await getCSRFToken("cache");
+      const response = await fetch(
+        `${CACHE_URL}/cache/${databaseName}/${tableInfo.tableName}`,
+        {
           method: "POST",
-          body: JSON.stringify(data),
+          body: JSON.stringify(cacheData),
           mode: "cors",
           credentials: "include",
           headers: {
             "Content-type": "application/json; charset=UTF-8",
             "X-CSRFToken": csrftoken,
           },
-        })
-          .then((response) => {
-            const newErrorState = !response.ok;
-            if (newErrorState) {
-              toast(
-                `Something went wrong when trying to store the start or end time: ${response.status} ${response.statusText}`,
-              );
-            }
-
-            setCacheError(newErrorState);
-          })
-          .catch((reason) => {
-            toast(
-              `Something went wrong when trying to store the start or end time: ${reason}`,
-            );
-            setCacheError(true);
-          });
-      })
-      .catch((reason: string) => {
+        },
+      );
+      const newErrorState = !response.ok;
+      if (newErrorState) {
         toast(
-          `Something went wrong when trying to store the start or end time: ${reason}`,
+          `Something went wrong when trying to store the start or end time: ${response.status} ${response.statusText}`,
         );
-        setCacheError(true);
-      })
-      .finally(() => {
-        setIsCaching(false);
-      });
+      }
+      setCacheError(newErrorState);
+    } catch (reason) {
+      toast(
+        `Something went wrong when trying to store the start or end time: ${reason}`,
+      );
+      setCacheError(true);
+    } finally {
+      setIsCaching(false);
+    }
   }
 
-  function start() {
-    // only allow one concurrent cache operation (avoid race condition)
+  // Starts a new timing session: populates start-time columns and caches them
+  async function start() {
     if (isCaching) return;
     setIsCaching(true);
 
     setIsSplit(false);
 
-    handleRecordOn({}, tableInfo, "start", toast)
-      .then((newData: Record<string, any>) => {
-        setData(newData);
-      })
-      .catch((reason?: any) => {
-        if (reason) toast(`Failed to start: ${reason}`);
-        setCacheError(true);
-      });
+    try {
+      await populate("start");
+      await cache();
+    } catch (reason) {
+      if (reason) toast(`Failed to start: ${reason}`);
+      setCacheError(true);
+    }
   }
 
-  /**
-   * Splits the time & records the start & end time in the cache.
-   */
-  function split() {
-    // only allow one concurrent cache operation (avoid race condition)
+  // Ends the current timing segment: populates split-time columns and caches them
+  async function split() {
     if (isCaching) return;
     setIsCaching(true);
 
-    handleRecordOn(data, tableInfo, "split", toast)
-      .then((newData: Record<string, any>) => {
-        setData(newData);
-        setIsSplit(true);
-      })
-      .catch((reason?: any) => {
-        if (reason) toast(`Failed to split: ${reason}`);
-        setCacheError(true);
-      });
+    try {
+      await populate("split");
+      setIsSplit(true);
+      await cache();
+      if (tableInfo.tagging && tagNames) {
+        controller.setValue("data.primary_tag", tagNames["data"][0][0]);
+      }
+    } catch (reason) {
+      if (reason) toast(`Failed to split: ${reason}`);
+      setCacheError(true);
+    }
   }
 
-  /**
-   * Undos and removes the end time from the cache but keeps the start time.
-   */
-  function cancelSplit() {
+  // Undoes the split: purges split-time columns from the controller and cache
+  async function cancelSplit() {
     if (isCaching) return;
     setIsCaching(true);
 
-    handleRecordOn(data, tableInfo, "split", toast, "purge")
-      .then((newData: Record<string, any>) => {
-        setData(newData);
-        setIsSplit(false);
-      })
-      .catch((reason?: any) => {
-        if (reason) toast(`Failed to cancel split: ${reason}`);
-        setCacheError(true);
-      });
+    try {
+      await populate("split", "purge");
+      setIsSplit(false);
+      await cache();
+    } catch (reason) {
+      if (reason) toast(`Failed to cancel split: ${reason}`);
+      setCacheError(true);
+    }
   }
 
-  /**
-   * Completely empty the cache (both start and end times)
-   */
-  function cancel() {
+  // Cancels the entire session: clears the cache and resets split state
+  async function cancel() {
     if (isCaching) return;
     setIsCaching(true);
 
     setIsSplit(false);
-
-    setData({});
+    await cache({});
   }
 
+  // Handles form entry submission, then restarts or cancels based on the clicked button's value
   function onSubmit(
     values: z.infer<typeof schema>,
     event?: React.BaseSyntheticEvent,
@@ -369,6 +306,7 @@ export function TimerForm({
       });
   }
 
+  // Logs and notifies the user when form validation fails
   function onSubmitInvalid(errors: FieldErrors<z.infer<typeof schema>>) {
     console.error("Invalid form submission.", errors);
     toast("Invalid form submission.");
@@ -382,7 +320,7 @@ export function TimerForm({
           <Button onClick={fetchCache}>
             <RefreshCcw></RefreshCcw>
           </Button>
-          <Button onClick={cache}>
+          <Button onClick={() => cache()}>
             <Upload />
           </Button>
         </div>
@@ -400,15 +338,13 @@ export function TimerForm({
         </div>
       );
 
-    if (tagNames === undefined)
+    if (tagsError || tagNames === undefined)
       return (
         <div className="flex flex-col items-center">
           <p>Error while loading tags.</p>
           <Button
             onClick={() => {
-              if (!tagsLoading) {
-                setTagsRefreshState(tagsRefreshState + 1);
-              }
+              setTagsRefreshState(tagsRefreshState + 1);
             }}
           >
             <RefreshCcw />
@@ -437,7 +373,10 @@ export function TimerForm({
         <Columns fieldsToEnter={tableInfo.schema} form={controller} />
         {/* Quick actions */}
         {/* Tags */}
-        {tableInfo.tagging && <Tags tagsDataset={tagNames} form={controller} />}
+        {tableInfo.tagging && (
+          // type assertion: useDataset validates against TAG_NAMES_DATASET_SCHEMA internally
+          <Tags tagsDataset={tagNames as TAG_NAMES_DATASET} form={controller} />
+        )}
         {/* Descriptors */}
         {tableInfo.descriptors && (
           <Descriptors tableInfo={tableInfo} form={controller} />
@@ -465,7 +404,7 @@ export function TimerForm({
 
   return (
     <div className="flex flex-col items-center">
-      <p>{isStart ? data["start_time"].toLocaleString() : "No start time."}</p>
+      <p>{isStart ? startTime.toLocaleString() : "No start time."}</p>
       <div className="flex flex-row justify-center">
         <Button
           className="min-w-[16ch]"

--- a/apps/astro-app/src/components/data/data-entry/timer.tsx
+++ b/apps/astro-app/src/components/data/data-entry/timer.tsx
@@ -1,4 +1,3 @@
-import type { TableInfo } from "@/types/data";
 import { Button } from "@/components/ui/button";
 import { useEffect, useState } from "react";
 import { Columns, Descriptors, Tags } from "@/components/data/data-entry";
@@ -20,21 +19,21 @@ import {
 } from "@utils/data/schema";
 import { toSnakeCase } from "@utils/parse";
 import { useAutoPopulate } from "@utils/data/form/useAutoPopulate";
+import {
+  useDatabaseName,
+  useTableInfo,
+} from "@utils/data/schema-context";
 
 /**
  * Timer based form component. Expects "Start Time" & "End Time" columns to be present.
- * @param databaseName The name of the database that this form gathers data for.
- * @param tableInfo The full table schema.
  */
 export function TimerForm({
-  databaseName,
-  tableInfo,
-  submissionCallback = () => {},
+  onSubmitted,
 }: {
-  databaseName: string;
-  tableInfo: TableInfo;
-  submissionCallback?: () => void;
+  onSubmitted?: () => void;
 }) {
+  const databaseName = useDatabaseName();
+  const tableInfo = useTableInfo()!;
   const [isSplit, setIsSplit] = useState<boolean>(false);
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const [tagsRefreshState, setTagsRefreshState] = useState<number>(0);
@@ -287,7 +286,7 @@ export function TimerForm({
     )
       .then(() => {
         toast("Form submitted!");
-        submissionCallback();
+        onSubmitted?.();
         controller.reset();
         switch (action) {
           case "split":
@@ -379,7 +378,7 @@ export function TimerForm({
         )}
         {/* Descriptors */}
         {tableInfo.descriptors && (
-          <Descriptors tableInfo={tableInfo} form={controller} />
+          <Descriptors form={controller} />
         )}
         {/* Submit & restart button */}
         <Button type="submit" disabled={isSubmitting} value="split">

--- a/apps/astro-app/src/components/data/entries/entry-table-page.tsx
+++ b/apps/astro-app/src/components/data/entries/entry-table-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { DescriptorInfo, TableInfo } from "@/types/data";
+import type { DatabaseInfo, DescriptorInfo, TableInfo } from "@/types/data";
 import type { JSX } from "astro/jsx-runtime";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -11,10 +11,13 @@ import { OriginPicker } from "@/components/data/origin-picker";
 import { CACHE_CSRF_ENDPOINT, getCSRFToken } from "@utils/auth";
 import { GenericEntryTable } from "./entry-table";
 import { TaggingTable } from "./tagging-table";
+import {
+  SchemaProvider,
+  useDatabaseName,
+  useTableName,
+} from "@utils/data/schema-context";
 
 export interface EntryTableProps {
-  databaseName: string;
-  tableName: string;
   endpoint: string;
   refreshTrigger: number;
 }
@@ -22,20 +25,20 @@ export interface EntryTableProps {
 /**
  * Renders an EntryTable to view and modify entries on specific tables.
  * @param schema The schema of the table.
- * @param databaseName The name of the target database
- * @param tableName The name of the parent table, or the target table if the table has no parent.
+ * @param databaseInfo The full database info.
+ * @param tableInfo The full table info.
  * @param type The type of table to render. Is either undefined (generic) or a tagging table type.
  * @returns an EntryTable component.
  */
 export function EntryTable({
   schema,
-  databaseName,
-  tableName,
+  databaseInfo,
+  tableInfo,
   type,
 }: {
   schema?: TableInfo | DescriptorInfo | undefined;
-  databaseName: string;
-  tableName: string;
+  databaseInfo: DatabaseInfo;
+  tableInfo: TableInfo;
   type?:
     | undefined
     | "tags"
@@ -45,6 +48,29 @@ export function EntryTable({
     | "descriptors"
     | "data";
 }): JSX.Element {
+  return (
+    <SchemaProvider databaseInfo={databaseInfo} tableInfo={tableInfo}>
+      <EntryTableBody schema={schema} type={type} />
+    </SchemaProvider>
+  );
+}
+
+function EntryTableBody({
+  schema,
+  type,
+}: {
+  schema?: TableInfo | DescriptorInfo | undefined;
+  type?:
+    | undefined
+    | "tags"
+    | "tag_names"
+    | "tag_aliases"
+    | "tag_groups"
+    | "descriptors"
+    | "data";
+}): JSX.Element {
+  const databaseName = useDatabaseName();
+  const tableName = useTableName()!;
   const [origin, setOrigin] = useState<string>(CACHE_URL);
   const [refreshTrigger, setRefreshTrigger] = useState<number>(0);
   const [pullTrigger, setPullTrigger] = useState<number>(0);
@@ -64,8 +90,6 @@ export function EntryTable({
   let table: JSX.Element = null;
   // params applicable to every type of entry table
   const genericEntryTableParams: EntryTableProps = {
-    databaseName: databaseName,
-    tableName: tableName,
     endpoint: endpoint,
     refreshTrigger: refreshTrigger,
   };

--- a/apps/astro-app/src/components/data/entries/entry-table.tsx
+++ b/apps/astro-app/src/components/data/entries/entry-table.tsx
@@ -24,6 +24,10 @@ import { safeFetchDataset } from "@utils/data/http";
 import { ZodError, type ZodType } from "zod";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import type { EntryTableProps } from "./entry-table-page";
+import {
+  useDatabaseName,
+  useTableName,
+} from "@utils/data/schema-context";
 
 /**
  * Fetches the data from the endpoint and assumes the data to be of the specified type.
@@ -148,8 +152,6 @@ interface GenericEntryTableProps extends EntryTableProps {
 /**
  * A generic entry editor table.
  * @param schema The table schema.
- * @param databaseName The name of the database that contains the target table.
- * @param tableName The name of the parent table (or the target table if there is no parent).
  * @param endpoint The endpoint prefix to get data from. (i.e. DATABASE_URL or CACHE_URL/main)
  * @param refreshTrigger A controlled field to trigger a refresh through useEffect.
  * @param type The table type to fetch.
@@ -157,12 +159,12 @@ interface GenericEntryTableProps extends EntryTableProps {
  */
 export function GenericEntryTable({
   schema,
-  databaseName,
-  tableName,
   endpoint,
   refreshTrigger,
   type,
 }: GenericEntryTableProps): JSX.Element {
+  const databaseName = useDatabaseName();
+  const tableName = useTableName()!;
   const datasetSchema = useMemo(
     () =>
       getZodDatasetType(

--- a/apps/astro-app/src/components/data/entries/entry-table.tsx
+++ b/apps/astro-app/src/components/data/entries/entry-table.tsx
@@ -21,10 +21,12 @@ import {
 } from "@/components/ui/table";
 import { getZodDatasetType } from "@utils/data/schema";
 import { safeFetchDataset } from "@utils/data/http";
+import { toSnakeCase } from "@utils/parse";
 import { ZodError, type ZodType } from "zod";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import type { EntryTableProps } from "./entry-table-page";
 import {
+  useDatabaseInfo,
   useDatabaseName,
   useTableName,
 } from "@utils/data/schema-context";
@@ -96,6 +98,51 @@ export function DatasetTable({
     return output;
   }, []);
 
+  const dbInfo = useDatabaseInfo();
+  const curTableName = useTableName();
+  const databaseName = useDatabaseName();
+  const pointerColumnMap = useMemo(() => {
+    const map: Record<
+      number,
+      {
+        targetTable?: string;
+        typeColumnIndex?: number;
+        references?: string[];
+      }
+    > = {};
+
+    if (!curTableName) return map;
+
+    const tableInfo = dbInfo.tables.find(
+      (t) => t.tableName === curTableName,
+    );
+    if (!tableInfo) return map;
+
+    for (const col of tableInfo.schema) {
+      const colSnake = toSnakeCase(col.name);
+      const colIndex = dataset.columns.indexOf(colSnake);
+      if (colIndex === -1) continue;
+
+      if (col.datatype === "pointer" && col.references) {
+        map[colIndex] = { targetTable: col.references };
+      } else if (
+        (col.datatype === "polypointer" ||
+          col.datatype === "polymorphic pointer") &&
+        col.references &&
+        typeof col.references === "object"
+      ) {
+        const typeColSnake = toSnakeCase(col.name + " Type");
+        const typeIndex = dataset.columns.indexOf(typeColSnake);
+        map[colIndex] = {
+          references: col.references,
+          typeColumnIndex: typeIndex !== -1 ? typeIndex : undefined,
+        };
+      }
+    }
+
+    return map;
+  }, [dbInfo, curTableName, dataset.columns]);
+
   return (
     <ScrollArea orientation="horizontal">
       <Table>
@@ -126,13 +173,49 @@ export function DatasetTable({
                   )}
                 </TableCell>
                 {/* Other data */}
-                {indexesToDisplay.map((indexToDisplay: number) => (
-                  <TableCell
-                    key={`entry-table-cell-${indexToDisplay}-${entryIndex}`}
-                  >
-                    {String(row[indexToDisplay])}
-                  </TableCell>
-                ))}
+                {indexesToDisplay.map((indexToDisplay: number) => {
+                  const pointerInfo = pointerColumnMap[indexToDisplay];
+                  const cellValue = row[indexToDisplay];
+
+                  if (pointerInfo) {
+                    let targetTable = pointerInfo.targetTable;
+
+                    if (
+                      pointerInfo.typeColumnIndex !== undefined &&
+                      pointerInfo.references
+                    ) {
+                      const typeValue = String(
+                        row[pointerInfo.typeColumnIndex],
+                      );
+                      targetTable =
+                        pointerInfo.references.find(
+                          (r) => toSnakeCase(r) === toSnakeCase(typeValue),
+                        ) ?? "";
+                    }
+
+                    if (targetTable) {
+                      return (
+                        <TableCell
+                          key={`entry-table-cell-${indexToDisplay}-${entryIndex}`}
+                        >
+                          <a
+                            href={`/data/${toSnakeCase(databaseName)}/${toSnakeCase(targetTable)}/explore/data?pkey=${cellValue}`}
+                          >
+                            {String(cellValue)}
+                          </a>
+                        </TableCell>
+                      );
+                    }
+                  }
+
+                  return (
+                    <TableCell
+                      key={`entry-table-cell-${indexToDisplay}-${entryIndex}`}
+                    >
+                      {String(cellValue)}
+                    </TableCell>
+                  );
+                })}
               </TableRow>
             ),
           )}

--- a/apps/astro-app/src/components/data/entries/entry-viewer.tsx
+++ b/apps/astro-app/src/components/data/entries/entry-viewer.tsx
@@ -289,7 +289,7 @@ export function EntryViewer({
       case "data":
       case "descriptors":
         return getZodEntrySchema(schema).extend({
-          id: z.number().int().min(1),
+          id: z.int().min(1),
         });
       case "tag_aliases":
         return TAGGING_TABLE_TAG_ALIASES_SCHEMA;

--- a/apps/astro-app/src/components/data/entries/entry-viewer.tsx
+++ b/apps/astro-app/src/components/data/entries/entry-viewer.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import type { DatabaseInfo, DescriptorInfo, TableInfo, TableType } from "@/types/data";
+import type {
+  DatabaseInfo,
+  DescriptorInfo,
+  TableInfo,
+  TableType,
+} from "@/types/data";
 import { type OriginName } from "@/types/http";
 import {
   safeFetchDataset,
@@ -33,7 +38,7 @@ import {
   type TAGS_DATASET,
 } from "@utils/data/schema";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useForm, type FieldErrors } from "react-hook-form";
+import { FormProvider, useForm, type FieldErrors } from "react-hook-form";
 import z from "zod";
 import { toast } from "sonner";
 import { resolveEndpoint } from "@utils/data/endpoints";
@@ -66,9 +71,40 @@ export function EntryViewer({
   descriptorName?: string;
   type?: TableType;
 }) {
+  const entrySchema = useMemo(() => {
+    switch (type) {
+      case "data":
+      case "descriptors":
+        return getZodEntrySchema(schema).extend({
+          id: z.int().min(1),
+        });
+      case "tag_aliases":
+        return TAGGING_TABLE_TAG_ALIASES_SCHEMA;
+      case "tag_groups":
+        return TAGGING_TABLE_TAG_GROUPS_SCHEMA;
+      case "tag_names":
+        return TAGGING_TABLE_TAG_NAMES_SCHEMA;
+      case "tags":
+        return TAGGING_TABLE_TAGS_SCHEMA;
+      default:
+        throw new Error(`Unknown table type: ${type}`);
+    }
+  }, [schema]);
+
+  const controller = useForm({
+    resolver: zodResolver(entrySchema),
+  });
+
   return (
     <SchemaProvider databaseInfo={databaseInfo} tableInfo={tableInfo}>
-      <EntryViewerBody schema={schema} descriptorName={descriptorName} type={type} />
+      <FormProvider {...controller}>
+        <EntryViewerBody
+          schema={schema}
+          descriptorName={descriptorName}
+          type={type}
+          controller={controller}
+        />
+      </FormProvider>
     </SchemaProvider>
   );
 }
@@ -77,10 +113,12 @@ function EntryViewerBody({
   schema,
   descriptorName,
   type = "data",
+  controller,
 }: {
   schema: TableInfo | DescriptorInfo;
   descriptorName?: string;
   type?: TableType;
+  controller: ReturnType<typeof useForm>;
 }) {
   const databaseName = useDatabaseName();
   const tableName = useTableName()!;
@@ -307,28 +345,7 @@ function EntryViewerBody({
   // END - data tables
 
   // START - edit entry
-  const entrySchema = useMemo(() => {
-    switch (type) {
-      case "data":
-      case "descriptors":
-        return getZodEntrySchema(schema).extend({
-          id: z.int().min(1),
-        });
-      case "tag_aliases":
-        return TAGGING_TABLE_TAG_ALIASES_SCHEMA;
-      case "tag_groups":
-        return TAGGING_TABLE_TAG_GROUPS_SCHEMA;
-      case "tag_names":
-        return TAGGING_TABLE_TAG_NAMES_SCHEMA;
-      case "tags":
-        return TAGGING_TABLE_TAGS_SCHEMA;
-    }
-  }, [schema]);
-  const controller = useForm({
-    resolver: zodResolver(entrySchema),
-    // defaultValues: getDefaultValues(schema),
-  });
-  function onSubmit(values: z.infer<typeof entrySchema>) {
+  function onSubmit(values: any) {
     const endpoint = resolveEndpoint(origin, type, entryEndpointOptions);
     if (endpoint === undefined) {
       console.error("Form submission failed: Could not resolve endpoint.");

--- a/apps/astro-app/src/components/data/entries/entry-viewer.tsx
+++ b/apps/astro-app/src/components/data/entries/entry-viewer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { DescriptorInfo, TableInfo, TableType } from "@/types/data";
+import type { DatabaseInfo, DescriptorInfo, TableInfo, TableType } from "@/types/data";
 import { type OriginName } from "@/types/http";
 import {
   safeFetchDataset,
@@ -39,6 +39,11 @@ import { toast } from "sonner";
 import { resolveEndpoint } from "@utils/data/endpoints";
 import { Columns, PrimaryTag } from "../data-entry";
 import { Spinner } from "@/components/ui/spinner";
+import {
+  SchemaProvider,
+  useDatabaseName,
+  useTableName,
+} from "@utils/data/schema-context";
 
 function EntryViewerError({ message }: { message: string }) {
   return (
@@ -50,17 +55,35 @@ function EntryViewerError({ message }: { message: string }) {
 
 export function EntryViewer({
   schema,
-  databaseName,
-  tableName,
+  databaseInfo,
+  tableInfo,
   descriptorName,
   type = "data",
 }: {
   schema: TableInfo | DescriptorInfo;
-  databaseName: string;
-  tableName: string;
+  databaseInfo: DatabaseInfo;
+  tableInfo: TableInfo;
   descriptorName?: string;
   type?: TableType;
 }) {
+  return (
+    <SchemaProvider databaseInfo={databaseInfo} tableInfo={tableInfo}>
+      <EntryViewerBody schema={schema} descriptorName={descriptorName} type={type} />
+    </SchemaProvider>
+  );
+}
+
+function EntryViewerBody({
+  schema,
+  descriptorName,
+  type = "data",
+}: {
+  schema: TableInfo | DescriptorInfo;
+  descriptorName?: string;
+  type?: TableType;
+}) {
+  const databaseName = useDatabaseName();
+  const tableName = useTableName()!;
   const [id, setId] = useState<number | null>(() => {
     if (window == undefined) return null;
     const primaryKey = Number(

--- a/apps/astro-app/src/components/data/entries/tagging-table.tsx
+++ b/apps/astro-app/src/components/data/entries/tagging-table.tsx
@@ -21,6 +21,10 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { toSnakeCase } from "@utils/parse";
 import { DatasetTable, getData } from "./entry-table";
 import type { EntryTableProps } from "./entry-table-page";
+import {
+  useDatabaseName,
+  useTableName,
+} from "@utils/data/schema-context";
 
 interface TaggingEntryTableProps extends EntryTableProps {
   type: "tags" | "tag_names" | "tag_aliases" | "tag_groups";
@@ -28,20 +32,18 @@ interface TaggingEntryTableProps extends EntryTableProps {
 
 /**
  * TAGGING SUB-TABLES ONLY: Render an entry table full of data and a form at the bottom to insert new entries in.
- * @param databaseName The name of the database that contains the target table.
- * @param tableName The name of the parent table (or the target table if there is no parent).
  * @param endpoint The endpoint prefix to get data from. (i.e. DATABASE_URL or CACHE_URL/main)
  * @param refreshTrigger A controlled field to trigger a refresh through useEffect.
  * @param type The type of TaggingTable to render.
  * @returns
  */
 export function TaggingTable({
-  databaseName,
-  tableName,
   endpoint,
   refreshTrigger,
   type,
 }: TaggingEntryTableProps) {
+  const databaseName = useDatabaseName();
+  const tableName = useTableName()!;
   const [data, setData] = useState<Dataset>();
   const [loading, setLoading] = useState<boolean>(true);
 

--- a/apps/astro-app/src/components/data/entries/tagging-table.tsx
+++ b/apps/astro-app/src/components/data/entries/tagging-table.tsx
@@ -16,7 +16,7 @@ import {
 } from "@utils/data/schema";
 import { submitEntry } from "@utils/data/http";
 import { z } from "zod";
-import { useForm, type FieldErrors } from "react-hook-form";
+import { FormProvider, useForm, type FieldErrors } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { toSnakeCase } from "@utils/parse";
 import { DatasetTable, getData } from "./entry-table";
@@ -130,16 +130,18 @@ export function TaggingTable({
   );
 
   return (
-    <form onSubmit={controller.handleSubmit(onSubmit, onSubmitInvalid)}>
-      <DatasetTable
-        dataset={data}
-        footer={footer}
-        readonly={false}
-        explorePath={`/data/${databaseName}/${tableName}/explore/${type}`}
-      ></DatasetTable>
-      <Button className="w-full" type="submit">
-        <Plus />
-      </Button>
-    </form>
+    <FormProvider {...controller}>
+      <form onSubmit={controller.handleSubmit(onSubmit, onSubmitInvalid)}>
+        <DatasetTable
+          dataset={data}
+          footer={footer}
+          readonly={false}
+          explorePath={`/data/${databaseName}/${tableName}/explore/${type}`}
+        ></DatasetTable>
+        <Button className="w-full" type="submit">
+          <Plus />
+        </Button>
+      </form>
+    </FormProvider>
   );
 }

--- a/apps/astro-app/src/components/data/input-element/polypointer-input.tsx
+++ b/apps/astro-app/src/components/data/input-element/polypointer-input.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import type { DataColumn } from "@/types/data";
+import { useDatabaseName } from "@utils/data/schema-context";
+import { useFormContext } from "react-hook-form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { RemoteSearchSelect } from "./remote-search-select";
+
+/**
+ * Input element for polypointer columns: type dropdown + remote search select.
+ * @param columnInfo - column schema info
+ * @param fieldName - snake_cased name of the polypointer column
+ * @param formFieldName - full RHF field path for the polypointer column ID (e.g. "descriptors.related_item[0].related_item"). When set, the _type subcolumn path is derived from this. Falls back to fieldName for root-level use.
+ * @param value - current polypointer ID value
+ * @param onChange - called when the ID changes
+ */
+export function PolypointerInput({
+  columnInfo,
+  fieldName,
+  formFieldName,
+  value,
+  onChange,
+}: {
+  columnInfo: DataColumn;
+  fieldName: string;
+  formFieldName?: string;
+  value: number | undefined;
+  onChange: (v: number | undefined) => void;
+}) {
+  const formContext = useFormContext();
+  const databaseName = useDatabaseName();
+  const idFieldName = formFieldName ?? fieldName;
+  const typeFieldName = formFieldName
+    ? `${formFieldName}_type`
+    : `${fieldName}_type`;
+  const currentType = formContext.watch(typeFieldName) as string | undefined;
+
+  const refs =
+    (columnInfo as DataColumn & { references?: string[] }).references ?? [];
+  const typeOptions = refs.map((tableName) => ({
+    key: tableName,
+    tableName,
+    displayName: tableName,
+  }));
+
+  return (
+    <div className="flex flex-col gap-2 items-center">
+      <Select
+        value={currentType ?? ""}
+        onValueChange={(val) => {
+          formContext.setValue(typeFieldName, val);
+          formContext.setValue(idFieldName, undefined);
+        }}
+      >
+        <SelectTrigger className="w-[200px]">
+          <SelectValue placeholder="Select type..." />
+        </SelectTrigger>
+        <SelectContent>
+          {typeOptions.map((opt) => (
+            <SelectItem key={opt.key} value={opt.key}>
+              {opt.displayName}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      {currentType && refs.includes(currentType) && (
+        <RemoteSearchSelect
+          databaseName={databaseName}
+          tableName={currentType}
+          value={value}
+          onChange={onChange}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/astro-app/src/components/data/input-element/remote-search-select.tsx
+++ b/apps/astro-app/src/components/data/input-element/remote-search-select.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { Check, ChevronsUpDown, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { useEffect, useState } from "react";
+import { useSearch, safeSearchFetch } from "@utils/data/search";
+import { DATABASE_URL } from "astro:env/client";
+import { toSnakeCase } from "@utils/parse";
+import { Spinner } from "@/components/ui/spinner";
+
+export function RemoteSearchSelect({
+  databaseName,
+  tableName,
+  placeholder = "Search...",
+  value,
+  onChange,
+}: {
+  databaseName: string;
+  tableName: string;
+  placeholder?: string;
+  value: number | undefined;
+  onChange: (v: number | undefined) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [initialLabel, setInitialLabel] = useState<string | undefined>(
+    undefined,
+  );
+
+  const [results, loading] = useSearch({
+    databaseName,
+    tableName,
+    q: query,
+  });
+
+  // On mount with an existing value, resolve its label
+  useEffect(() => {
+    if (value === undefined || initialLabel !== undefined) return;
+
+    const endpoint = `${DATABASE_URL}/${toSnakeCase(databaseName)}/${toSnakeCase(tableName)}/search`;
+    safeSearchFetch(endpoint, String(value))
+      .then((items) => {
+        const match = items.find((item) => item.id === value);
+        if (match) setInitialLabel(match.label);
+      })
+      .catch(() => {
+        // silently fail — just show the raw ID
+      });
+  }, [value]);
+
+  const displayLabel =
+    value !== undefined ? (initialLabel ?? String(value)) : placeholder;
+
+  function handleSelect(selectedId: number) {
+    onChange(selectedId);
+    setOpen(false);
+  }
+
+  function handleClear() {
+    onChange(undefined);
+    setInitialLabel(undefined);
+    setQuery("");
+  }
+
+  return (
+    <div className="flex flex-row items-center gap-2">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            role="combobox"
+            aria-expanded={open}
+            className="w-80 justify-between"
+          >
+            <span className="truncate">{displayLabel}</span>
+            <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-80 p-0">
+          <Command shouldFilter={false}>
+            <CommandInput
+              placeholder="Type to search..."
+              className="h-9"
+              value={query}
+              onValueChange={setQuery}
+            />
+            <CommandList>
+              {loading && (
+                <div className="py-2 text-center text-sm text-muted-foreground">
+                  Searching... <Spinner />
+                </div>
+              )}
+              <CommandEmpty>No results found.</CommandEmpty>
+              <CommandGroup>
+                {results.map((item) => (
+                  <CommandItem
+                    key={item.id}
+                    value={String(item.id)}
+                    onSelect={() => handleSelect(item.id)}
+                  >
+                    <span className="text-muted-foreground">{item.id}</span> {item.label}
+                    <Check
+                      className={cn(
+                        "ml-auto",
+                        value === item.id ? "opacity-100" : "opacity-0",
+                      )}
+                    />
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
+      {value !== undefined && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          onClick={handleClear}
+          aria-label="Clear selection"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/apps/astro-app/src/components/data/input-elements.tsx
+++ b/apps/astro-app/src/components/data/input-elements.tsx
@@ -35,10 +35,13 @@ import {
 import { Button } from "@/components/ui/button";
 import type { DataColumn, EnumColumn, SelectRestrictions } from "@/types/data";
 import { SearchSelect } from "./input-element/search-select";
-import { Controller } from "react-hook-form";
+import { Controller, useFormContext } from "react-hook-form";
 import { GeodeticPointMinimalInputElement } from "./input-element/geodetic-point-minimal";
 import { toSnakeCase } from "@utils/parse";
 import { NumberBox } from "./input-element/number-box";
+import { RemoteSearchSelect } from "./input-element/remote-search-select";
+import { PolypointerInput } from "./input-element/polypointer-input";
+import { useDatabaseName } from "@utils/data/schema-context";
 
 export interface FormElementProps {
   form: any;
@@ -318,6 +321,27 @@ function InputElement({
             })}
             defaultValue={columnInfo.defaultValue}
             {...field}
+          />
+        );
+        break;
+      case "pointer":
+        body = (
+          <RemoteSearchSelect
+            databaseName={useDatabaseName()}
+            tableName={columnInfo.references ?? ""}
+            value={field.value as number | undefined}
+            onChange={(v) => field.onChange(v)}
+          />
+        );
+        break;
+      case "polypointer":
+        body = (
+          <PolypointerInput
+            columnInfo={columnInfo}
+            fieldName={columnName}
+            formFieldName={field.name}
+            value={field.value as number | undefined}
+            onChange={(v) => field.onChange(v)}
           />
         );
         break;

--- a/apps/astro-app/src/pages/data/[databaseName]/[tableName]/dataentry.astro
+++ b/apps/astro-app/src/pages/data/[databaseName]/[tableName]/dataentry.astro
@@ -32,9 +32,6 @@ export function getStaticPaths() {
 } // It's crucial that this page loads as quickly as possible to provide the best experience.
 
 const { databaseName, tableName } = Astro.params;
-let entrytype: TableInfo["entrytype"] | undefined;
-
-// const fieldsToEnter: Array<DataColumn | JsonColumn> = Object.values(config.data.databases[databaseName].schema);
 
 const pageTitle: string =
   databaseName.charAt(0).toUpperCase() +
@@ -44,13 +41,14 @@ const pageTitle: string =
   tableName.slice(1) +
   " Data Entry";
 
+let databaseInfo: DatabaseInfo | undefined = undefined;
 let tableInfo: TableInfo | undefined = undefined;
 for (let i of config.data) {
   if (i.dbname == databaseName) {
+    databaseInfo = i;
     for (let j of i.tables) {
       if (j.tableName == tableName) {
         tableInfo = j;
-        entrytype = j.entrytype;
         break;
       }
     }
@@ -58,8 +56,7 @@ for (let i of config.data) {
   }
 }
 
-if (!tableInfo || !entrytype) {
-  // @todo say something isn't working
+if (!databaseInfo || !tableInfo) {
   return Astro.redirect("/");
 }
 ---
@@ -71,7 +68,7 @@ if (!tableInfo || !entrytype) {
 >
   <LoginDialog client:only="react" slot="top-bar-button2" />
   <DataEntryForm
-    databaseName={databaseName}
+    databaseInfo={databaseInfo}
     tableInfo={tableInfo}
     client:only="react"
   >

--- a/apps/astro-app/src/pages/data/[databaseName]/[tableName]/entries/[...slug].astro
+++ b/apps/astro-app/src/pages/data/[databaseName]/[tableName]/entries/[...slug].astro
@@ -146,8 +146,8 @@ switch (slug) {
   <LoginDialog client:only="react" slot="top-bar-button2" />
   <EntryTable
     schema={schema}
-    databaseName={databaseName}
-    tableName={tableName}
+    databaseInfo={databaseInfo}
+    tableInfo={tableInfo}
     type={type}
     client:load
   />

--- a/apps/astro-app/src/pages/data/[databaseName]/[tableName]/explore/[...slug].astro
+++ b/apps/astro-app/src/pages/data/[databaseName]/[tableName]/explore/[...slug].astro
@@ -167,8 +167,8 @@ switch (slug) {
   <LoginDialog client:only="react" slot="top-bar-button2" />
   <EntryViewer
     schema={schema}
-    databaseName={databaseName}
-    tableName={tableName}
+    databaseInfo={databaseInfo}
+    tableInfo={tableInfo}
     type={type}
     client:only
   />

--- a/apps/astro-app/src/pages/data/[databaseName]/[tableName]/graphs.astro
+++ b/apps/astro-app/src/pages/data/[databaseName]/[tableName]/graphs.astro
@@ -34,10 +34,12 @@ export function getStaticPaths() {
 const { databaseName, tableName } = Astro.params;
 
 // search for the table schema
+let databaseInfo: DatabaseInfo | undefined = undefined;
 let tableSchema: TableInfo | undefined = undefined;
 
 for (const dbinfo of config.data as DatabaseInfo[]) {
   if (dbinfo.dbname === databaseName) {
+    databaseInfo = dbinfo;
     for (const tableInfo of dbinfo.tables) {
       if (tableInfo.tableName === tableName) {
         tableSchema = tableInfo;
@@ -48,7 +50,7 @@ for (const dbinfo of config.data as DatabaseInfo[]) {
   }
 }
 
-if (!tableSchema) {
+if (!databaseInfo || !tableSchema) {
   throw new Error(`Table schema for ${databaseName}/${tableName} not found.`);
 }
 
@@ -68,7 +70,7 @@ const pageTitle: string =
 >
   <LoginDialog client:only="react" slot="top-bar-button2" />
   <DatasetControlPanel
-    databaseName={databaseName}
+    databaseInfo={databaseInfo}
     tableSchema={tableSchema}
     client:load
   />

--- a/apps/astro-app/src/types/data.d.ts
+++ b/apps/astro-app/src/types/data.d.ts
@@ -48,7 +48,10 @@ export type Datatype =
   | "time"
   | "timestamp"
   | "enum"
-  | "geodetic point";
+  | "geodetic point"
+  | "pointer"
+  | "polypointer"
+  | "polymorphic pointer";
 
 export type ResolvedDatatype =
   | "int"
@@ -59,7 +62,9 @@ export type ResolvedDatatype =
   | "time"
   | "timestamp"
   | "enum"
-  | "geodetic point";
+  | "geodetic point"
+  | "pointer"
+  | "polypointer";
 
 export interface GeodeticCoordinates {
   latitude: number;
@@ -172,6 +177,20 @@ type GeodeticPointColumn = {
   entrytype: "geodetic point" | "geodetic point minimal" | "none";
 };
 
+type PointerColumn = {
+  datatype: "pointer";
+  defaultValue: never;
+  entrytype: "pointer" | "none";
+  references?: string;
+};
+
+type PolyPointerColumn = {
+  datatype: "polypointer" | "polymorphic pointer";
+  defaultValue: never;
+  entrytype: "polypointer" | "none";
+  references?: string[];
+};
+
 export type RecordOnEvent = "start" | "split" | "submit";
 
 export type DataColumn = {
@@ -182,7 +201,8 @@ export type DataColumn = {
   comments?: boolean;
   description?: string;
   unique?: boolean;
-  record_on?: "start" | "split";
+  optional?: boolean;
+  record_on?: RecordOnEvent;
 } & (
   | IntegerColumn
   | FloatColumn
@@ -193,10 +213,12 @@ export type DataColumn = {
   | TimestampColumn
   | EnumColumn
   | GeodeticPointColumn
+  | PointerColumn
+  | PolyPointerColumn
 );
 
 export type ResolvedColumnSchema = DataColumn & {
-  entrytype: "none";
+  entrytype: "none" | "pointer" | "polypointer";
   datatype: ResolvedDatatype;
 };
 // END - Schema
@@ -219,6 +241,7 @@ export type VectorDataset = Record<string, Array<any>>;
 export type TableType =
   | "data"
   | "descriptors"
+  | "search"
   | "tags"
   | "tag_names"
   | "tag_aliases"

--- a/apps/astro-app/src/types/data.d.ts
+++ b/apps/astro-app/src/types/data.d.ts
@@ -172,6 +172,8 @@ type GeodeticPointColumn = {
   entrytype: "geodetic point" | "geodetic point minimal" | "none";
 };
 
+export type RecordOnEvent = "start" | "split" | "submit";
+
 export type DataColumn = {
   name: string;
   parser?: Datatype;

--- a/apps/astro-app/src/utils/data/endpoints.ts
+++ b/apps/astro-app/src/utils/data/endpoints.ts
@@ -98,7 +98,10 @@ export function resolveEndpoint(
   }
 
   try {
-    return endpointHelpers[source][endpointHelperTableType](options as any);
+    return endpointHelpers[source][endpointHelperTableType]({
+      ...options,
+      tableType: table_type,
+    } as any);
   } catch (error) {
     if (error instanceof Error) return undefined;
     throw error;

--- a/apps/astro-app/src/utils/data/endpoints.ts
+++ b/apps/astro-app/src/utils/data/endpoints.ts
@@ -13,6 +13,7 @@ export const endpointHelpers = {
     data: masterDatabaseDataEndpoint,
     descriptors: masterDatabaseDescriptorEndpoint,
     tagging: masterDatabaseTaggingEndpoint,
+    search: masterDatabaseSearchEndpoint,
   },
 } as const;
 
@@ -73,6 +74,13 @@ export function masterDatabaseTaggingEndpoint({
   return `${DATABASE_URL}/${databaseName}/${tableName}/${tableType}`;
 }
 
+export function masterDatabaseSearchEndpoint({
+  databaseName,
+  tableName,
+}: DATA_ENDPOINT_PARAMS): string {
+  return `${DATABASE_URL}/${databaseName}/${tableName}/search`;
+}
+
 export function resolveEndpoint(
   source: OriginName,
   table_type: TableType,
@@ -81,13 +89,16 @@ export function resolveEndpoint(
     | DESCRIPTOR_ENDPOINT_PARAMS
     | TAGGING_ENDPOINT_PARAMS,
 ) {
-  let endpointHelperTableType: "data" | "descriptors" | "tagging";
+  let endpointHelperTableType: "data" | "descriptors" | "search" | "tagging";
   switch (table_type) {
     case "data":
       endpointHelperTableType = "data";
       break;
     case "descriptors":
       endpointHelperTableType = "descriptors";
+      break;
+    case "search":
+      endpointHelperTableType = "search";
       break;
     case "tag_aliases":
     case "tag_groups":
@@ -98,6 +109,10 @@ export function resolveEndpoint(
   }
 
   try {
+    if (endpointHelperTableType === "search") {
+      // search is only available on master-database
+      return masterDatabaseSearchEndpoint(options as DATA_ENDPOINT_PARAMS);
+    }
     return endpointHelpers[source][endpointHelperTableType]({
       ...options,
       tableType: table_type,

--- a/apps/astro-app/src/utils/data/form/updates.ts
+++ b/apps/astro-app/src/utils/data/form/updates.ts
@@ -1,4 +1,4 @@
-import type { TableInfo } from "@/types/data";
+import type { TableInfo, RecordOnEvent } from "@/types/data";
 import {
   GeodeticCoordinate,
   GetCurrentGeodeticCoordinatePromise,
@@ -8,7 +8,7 @@ import { toSnakeCase } from "@utils/parse";
 export function handleRecordOn(
   initialData: Record<string, any>,
   tableInfo: TableInfo,
-  event_name: "start" | "split",
+  event_name: RecordOnEvent,
   printError: (msg: string) => unknown = (msg: string) => {},
   mode: "insert" | "purge" = "insert",
 ): Promise<Record<string, any>> {

--- a/apps/astro-app/src/utils/data/form/updates.ts
+++ b/apps/astro-app/src/utils/data/form/updates.ts
@@ -49,7 +49,10 @@ export function handleRecordOn(
                 fetchTasks.push(currentTask);
                 break;
               default:
-                throw `Column "${columnSchema.name}"'s datatype does not support record_on.`;
+                const msg = `Column "${columnSchema.name}"'s datatype ${columnSchema.datatype} does not support record_on.`;
+                console.warn(msg);
+                printError(msg);
+                continue;
             }
             break;
         }

--- a/apps/astro-app/src/utils/data/form/useAutoPopulate.ts
+++ b/apps/astro-app/src/utils/data/form/useAutoPopulate.ts
@@ -1,0 +1,47 @@
+import { useCallback, useState } from "react";
+import type { UseFormReturn } from "react-hook-form";
+import type { TableInfo, RecordOnEvent } from "@/types/data";
+import { handleRecordOn } from "@utils/data/form/updates";
+import { toast } from "sonner";
+
+/**
+ * Injects record_on column values into the form controller for a given event.
+ * Reads current form state via controller.getValues, runs handleRecordOn,
+ * then writes the merged values back via controller.setValue.
+ * @param tableInfo The table schema.
+ * @param controller The react-hook-form controller.
+ * @param printError Error display callback (defaults to toast).
+ */
+export function useAutoPopulate(
+  tableInfo: TableInfo,
+  controller: UseFormReturn<any>,
+  printError: (msg: string) => unknown = toast,
+) {
+  const [isPopulating, setIsPopulating] = useState<boolean>(false);
+
+  const populate = useCallback(
+    async (eventName: RecordOnEvent, mode: "insert" | "purge" = "insert") => {
+      setIsPopulating(true);
+      try {
+        const current = controller.getValues("data") ?? {};
+        const merged = await handleRecordOn(
+          current,
+          tableInfo,
+          eventName,
+          printError,
+          mode,
+        );
+        for (const [key, value] of Object.entries(merged)) {
+          controller.setValue(`data.${key}`, value, {
+            shouldValidate: true,
+          });
+        }
+      } finally {
+        setIsPopulating(false);
+      }
+    },
+    [tableInfo, controller, printError],
+  );
+
+  return { populate, isPopulating };
+}

--- a/apps/astro-app/src/utils/data/iterators.ts
+++ b/apps/astro-app/src/utils/data/iterators.ts
@@ -78,6 +78,19 @@ export function* resolveColumnSchema(
     case "text":
       yield { ...column, datatype: "str", entrytype: "none" };
       break;
+    case "pointer":
+      yield { ...column, datatype: "pointer", entrytype: "pointer" };
+      break;
+    case "polymorphic pointer":
+    case "polypointer":
+      yield { ...column, datatype: "polypointer", entrytype: "polypointer" };
+      yield {
+        ...column,
+        name: column.name + " Type",
+        datatype: "str",
+        entrytype: "none",
+      };
+      break;
   }
 
   if (column.comments) {
@@ -85,6 +98,7 @@ export function* resolveColumnSchema(
       name: column.name + "_comments",
       entrytype: "none",
       datatype: "str",
+      optional: true,
     };
   }
 }

--- a/apps/astro-app/src/utils/data/schema-context.tsx
+++ b/apps/astro-app/src/utils/data/schema-context.tsx
@@ -1,0 +1,67 @@
+import { createContext, useContext, type ReactNode } from "react";
+import type { DatabaseInfo, TableInfo } from "@/types/data";
+
+interface SchemaContextValue {
+  databaseInfo: DatabaseInfo | null;
+  tableInfo: TableInfo | null;
+}
+
+const SchemaContext = createContext<SchemaContextValue>({
+  databaseInfo: null,
+  tableInfo: null,
+});
+
+/**
+ * Provides SchemaContext to a React subtree. Wraps at the page level so that
+ * child components can access database/table info via hooks instead of prop drilling.
+ */
+export function SchemaProvider({
+  databaseInfo,
+  tableInfo = null,
+  children,
+}: {
+  databaseInfo: DatabaseInfo | null;
+  tableInfo?: TableInfo | null;
+  children: ReactNode;
+}) {
+  return (
+    <SchemaContext.Provider value={{ databaseInfo, tableInfo }}>
+      {children}
+    </SchemaContext.Provider>
+  );
+}
+
+/**
+ * Returns the current DatabaseInfo. Throws if called outside a SchemaProvider
+ * or when databaseInfo is null (pages outside the data system).
+ */
+export function useDatabaseInfo(): DatabaseInfo {
+  const ctx = useContext(SchemaContext);
+  if (!ctx.databaseInfo) {
+    throw new Error(
+      "useDatabaseInfo must be used within a SchemaProvider with a valid databaseInfo",
+    );
+  }
+  return ctx.databaseInfo;
+}
+
+/**
+ * Returns the current database name. Shorthand for useDatabaseInfo().dbname.
+ */
+export function useDatabaseName(): string {
+  return useDatabaseInfo().dbname;
+}
+
+/**
+ * Returns the current TableInfo, or null on pages without a table scope (e.g. dashboard).
+ */
+export function useTableInfo(): TableInfo | null {
+  return useContext(SchemaContext).tableInfo;
+}
+
+/**
+ * Returns the current table name, or null on the dashboard.
+ */
+export function useTableName(): string | null {
+  return useTableInfo()?.tableName ?? null;
+}

--- a/apps/astro-app/src/utils/data/schema.ts
+++ b/apps/astro-app/src/utils/data/schema.ts
@@ -147,13 +147,13 @@ export function getZodColumnSchema(columnInfo: DataColumn) {
       output = z
         .string()
         .regex(/^(?:[01]\d|2[0-3]):[0-5]\d(?::[0-5]\d(?:\.\d+)?)?Z?$/, {
-          message: "Invalid ISO time format",
+          error: "Invalid ISO time format",
         });
       break;
     // THIS IS BY NO MEANS ROBUST
     case "date":
       output = z.string().regex(/^[0-9]{1,4}-[0-9]{2}-[0-9]{2}$/, {
-        message: "Invalid Date format",
+        error: "Invalid Date format",
       });
       break;
     // THIS IS BY NO MEANS ROBUST

--- a/apps/astro-app/src/utils/data/schema.ts
+++ b/apps/astro-app/src/utils/data/schema.ts
@@ -212,11 +212,17 @@ export function getZodColumnSchema(columnInfo: DataColumn) {
         .nullable()
         .default(null);
       break;
+    case "pointer":
+    case "polymorphic pointer":
+    case "polypointer":
+      output = z.int().min(1);
+      break;
   }
 
   // traits that might apply to any column
   // optional
-  // output = output.optional();
+  if (columnInfo.optional === true && columnInfo.datatype !== "geodetic point")
+    output = output.optional();
 
   return output;
 }
@@ -239,6 +245,14 @@ export function getZodEntrySchema(entrySchema: TableInfo | DescriptorInfo) {
 
     // data column, default values are not injected
     outputShape[columnName] = getZodColumnSchema(columnInfo);
+
+    // polypointer type subcolumn
+    if (
+      columnInfo.datatype === "polymorphic pointer" ||
+      columnInfo.datatype === "polypointer"
+    ) {
+      outputShape[`${columnName}_type`] = z.string().transform((val) => toSnakeCase(val));
+    }
 
     // comments column
     // @TODO add length restriction

--- a/apps/astro-app/src/utils/data/schema.ts
+++ b/apps/astro-app/src/utils/data/schema.ts
@@ -86,24 +86,24 @@ export const TAGGING_TABLE_TAG_GROUPS_TABLE_SCHEMA = {
 // END - tagging table table schemas
 
 export const TAGGING_TABLE_TAGS_SCHEMA = z.object({
-  id: z.number().int().optional(),
-  entry_id: z.number().int(),
-  tag_id: z.number().int(),
+  id: z.int().optional(),
+  entry_id: z.int(),
+  tag_id: z.int(),
 });
 
 export const TAGGING_TABLE_TAG_NAMES_SCHEMA = z.object({
-  id: z.number().int().optional(),
+  id: z.int().optional(),
   tag_name: z.string(),
 });
 
 export const TAGGING_TABLE_TAG_ALIASES_SCHEMA = z.object({
   alias: z.string(),
-  tag_id: z.number().int(),
+  tag_id: z.int(),
 });
 
 export const TAGGING_TABLE_TAG_GROUPS_SCHEMA = z.object({
-  id: z.number().int().optional(),
-  tag_id: z.number().int(),
+  id: z.int().optional(),
+  tag_id: z.int(),
   group_name: z.string(),
 });
 
@@ -115,7 +115,7 @@ export function getZodColumnSchema(columnInfo: DataColumn) {
   switch (columnInfo.datatype) {
     case "int":
     case "integer":
-      output = z.number().int();
+      output = z.int();
       if ("min" in columnInfo && columnInfo.min !== undefined)
         output = (output as ZodNumber).max(columnInfo.min);
       if ("max" in columnInfo && columnInfo.max !== undefined)
@@ -256,21 +256,19 @@ export const TAGS_DATASET_SCHEMA = z.object({
     z.literal("entry_id"),
     z.literal("tag_id"),
   ]),
-  data: z.array(
-    z.tuple([z.number().int(), z.number().int(), z.number().int()]),
-  ),
+  data: z.array(z.tuple([z.int(), z.int(), z.int()])),
 });
 export type TAGS_DATASET = z.infer<typeof TAG_NAMES_DATASET_SCHEMA>;
 
 export const TAG_NAMES_DATASET_SCHEMA = z.object({
   columns: z.tuple([z.literal("id"), z.literal("tag_name")]),
-  data: z.array(z.tuple([z.number().int(), z.string()])),
+  data: z.array(z.tuple([z.int(), z.string()])),
 });
 export type TAG_NAMES_DATASET = z.infer<typeof TAG_NAMES_DATASET_SCHEMA>;
 
 export const TAG_ALIASES_DATASET_SCHEMA = z.object({
   columns: z.tuple([z.literal("alias"), z.literal("tag_id")]),
-  data: z.array(z.tuple([z.string(), z.number().int()])),
+  data: z.array(z.tuple([z.string(), z.int()])),
 });
 export type TAG_ALIASES_DATASET = z.infer<typeof TAG_NAMES_DATASET_SCHEMA>;
 
@@ -280,7 +278,7 @@ export const TAG_GROUPS_DATASET_SCHEMA = z.object({
     z.literal("tag_id"),
     z.literal("group_name"),
   ]),
-  data: z.array(z.tuple([z.number().int(), z.number().int(), z.string()])),
+  data: z.array(z.tuple([z.int(), z.int(), z.string()])),
 });
 export type TAG_GROUPS_DATASET = z.infer<typeof TAG_NAMES_DATASET_SCHEMA>;
 
@@ -297,7 +295,7 @@ export function getZodDatasetType(
   const rowSchema: Array<ZodType<any>> = [];
 
   // ID column
-  rowSchema.push(z.number().int());
+  rowSchema.push(z.int());
 
   // primary_tag column
   if (tagging) rowSchema.push(z.coerce.string().nonempty());

--- a/apps/astro-app/src/utils/data/search.ts
+++ b/apps/astro-app/src/utils/data/search.ts
@@ -1,0 +1,103 @@
+"use client";
+
+import { DATABASE_URL } from "astro:env/client";
+import { useEffect, useRef, useState } from "react";
+import { toSnakeCase } from "../parse";
+
+export type SearchResult = { id: number; label: string };
+
+/**
+ * Performs a GET request to the search endpoint with an AbortSignal.
+ * Returns the parsed SearchResult array. Throws on non-OK or parse failure.
+ */
+export async function safeSearchFetch(
+  endpoint: string,
+  q: string,
+  signal?: AbortSignal,
+): Promise<SearchResult[]> {
+  const response = await fetch(`${endpoint}?q=${encodeURIComponent(q)}`, {
+    method: "GET",
+    mode: "cors",
+    credentials: "include",
+    signal,
+  });
+  if (!response.ok) {
+    throw `Search request failed: ${response.status} ${response.statusText}`;
+  }
+  const json: unknown = await response.json();
+  if (!Array.isArray(json)) {
+    throw "Search response is not an array";
+  }
+  return json as SearchResult[];
+}
+
+/**
+ * React hook for debounced server-side search.
+ * Fires a GET to the master-database search endpoint when `q` settles.
+ * Cancels in-flight requests on new keystroke or unmount.
+ */
+export function useSearch({
+  databaseName,
+  tableName,
+  q,
+  debounceMs = 300,
+  minLength = 1,
+}: {
+  databaseName: string;
+  tableName: string;
+  q: string;
+  debounceMs?: number;
+  minLength?: number;
+}): [SearchResult[], boolean, string] {
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const abortRef = useRef<AbortController | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (q.length < minLength) {
+      setResults([]);
+      setError("");
+      setLoading(false);
+      return;
+    }
+
+    if (timerRef.current) clearTimeout(timerRef.current);
+
+    timerRef.current = setTimeout(() => {
+      if (abortRef.current) abortRef.current.abort();
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+      setLoading(true);
+      setError("");
+
+      const endpoint = `${DATABASE_URL}/${toSnakeCase(databaseName)}/${toSnakeCase(tableName)}/search`;
+
+      safeSearchFetch(endpoint, q, controller.signal)
+        .then((data) => {
+          setResults(data);
+          setLoading(false);
+        })
+        .catch((err) => {
+          if (controller.signal.aborted) return;
+          setError(String(err));
+          setLoading(false);
+        });
+    }, debounceMs);
+
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [databaseName, tableName, q, debounceMs, minLength]);
+
+  // Abort in-flight on unmount
+  useEffect(() => {
+    return () => {
+      if (abortRef.current) abortRef.current.abort();
+    };
+  }, []);
+
+  return [results, loading, error];
+}


### PR DESCRIPTION
# PR: Pointers & Polypointers + Schema Context Migration

**Branch:** `pointers` → `main`

## Summary

25 files changed, ~1079 insertions, ~360 deletions. Three areas of work:

### 1. Schema Context (useContext migration)

Replaces prop-drilling of `databaseName`/`tableInfo` with React Context.

- **New:** `src/utils/data/schema-context.tsx` — `SchemaProvider` + accessor hooks (`useDatabaseName`, `useDatabaseInfo`, `useTableName`, `useTableInfo`)
- **Migrated components:** `DatasetControlPanel`, `Dashboard`, `DataEntryForm`, `FormForm`, `TimerForm`, `DataEntry` (`Columns`/`Descriptors`), `EntryViewer`, `EntryTable`, `EntryTablePage`, `TaggingTable`, `GraphsPage`
- Removes `databaseName` / `tableInfo` as props from all migrated components

### 2. Pointers & Polypointers

- **New:** `src/components/data/input-element/polypointer-input.tsx` — UX for selecting pointer values (links to other records)
- **New:** `src/components/data/input-element/remote-search-select.tsx` — remote search-based select for pointer targets
- **New:** `src/utils/data/search.ts` — utility for fetching pointer search results from the API
- `src/utils/data/schema.ts` — extended to handle pointer column types in dataset schemas
- `src/components/data/input-elements.tsx` — registers polypointer input in the element switch
- `src/types/data.d.ts` — extended with `DatabaseInfo` and pointer-related types

### 3. Form improvements

- **FormForm (`data-entry/form.tsx`):**
  - Uses `FormProvider` + `react-hook-form` context properly
  - Tag loading (`useDataset` hook replaces manual `safeFetchDataset`)
  - Descriptors support
  - Auto-populate support (`useAutoPopulate` hook)
  - Double-click guard on submit button
- **TimerForm (`data-entry/timer.tsx`):**
  - Switched from local state (`setData`) to `react-hook-form` controller + `watch`
  - Tag loading via `useDataset` hook
  - Auto-populate support
  - Cleaned up `cache()` function (async/await, no callback nesting)
- **New:** `src/utils/data/form/useAutoPopulate.ts` — auto-populates form fields on "start" and "submit" events

### 4. Bug fixes

- `resolveEndpoint` no longer requires `tableType` param
- Submission race condition in `TimerForm` fixed
- User passwords redacted
- Timer form double-submission guard
- Warn (not throw) on mismatched `record_on` event

## Commits (9, newest first)

| Hash | Description |
|------|-------------|
| `1504bc8` | feat: pointers & polypointers |
| `d3c0f9f` | refactor: begin useContext migration |
| `7c4e9ac` | feat: Form feature consistency |
| `1ddd4ce` | fix: more robust resolveEndpoint |
| `483c4bb` | warn instead of throw on mismatching record_on event |
| `c25115a` | fix: submission race condition in timer form |
| `5c97a83` | fix: redact user passwords |
| `112a5f8` | Migrate to z.int() |
| `e34a4b1` | chore: Migrate Zod error message param name to error |

## Notes

- `SchemaProvider` wrappers added at page level in `dataentry.astro`, `entries/[...slug].astro`, `explore/[...slug].astro`, `graphs.astro`
- TypeScript `verbatimModuleSyntax` requires `import type` — followed throughout
- The `useDataset` hook (imported from `@utils/data/http`) replaced ad-hoc `safeFetchDataset` calls in both forms
- **@TODO in code:** `schema-context.tsx` provider + useEffect hook still needs implementation (stub exists per AGENTS.md)
- **@TODO in code:** Tag suggestions — pick the most likely tag instead of the first one
